### PR TITLE
Router enhancement

### DIFF
--- a/src/collections/Router.js
+++ b/src/collections/Router.js
@@ -82,10 +82,10 @@ const methods = {
     function getAttributeValue(node) {
       if (node.type === 'Literal') {
         return node.value;
-      } else if (node.type === 'JSXExpressionContainer' &&
-        node.expression.type === 'Identifier') {
-        // TODO: Identifier 时应该如何展现? Router 应该处理和 Component 之间的关系
+      } else if (node.expression.type === 'Identifier') {
         return node.expression.name;
+      } else if (node.type === 'JSXExpressionContainer') {
+        return j(node.expression).toSource();
       }
       throw new Error(`getRouterTree: unsupported attribute type`);
     }

--- a/src/collections/Router.js
+++ b/src/collections/Router.js
@@ -65,6 +65,11 @@ const methods = {
         ret.id = `${ret.type}-root`;
       }
 
+      // 有些特殊情况 id 会重复（同样的父子路由，出现在多处，可能父亲的父亲不一样）
+      if (routeByIds[ret.id]) {
+        ret.id = `${ret.id}_${Math.random()}`;
+      }
+
       if (node.children) {
         ret.children = node.children
           .filter(node => node.type === 'JSXElement')


### PR DESCRIPTION
- 如果 attribute 的值是一个复杂的表达式，则直接展示
- 目前的 id 规则采用父子拼接的方式，有可能出现同样的父子路由出现在多处，紧紧是父亲的父亲 path 不一样，针对这种情况，目前没有特别好的办法，暂时加了个随机数

> 临时 fix，有空还得看下有没有更好的做法